### PR TITLE
Move Centos 7 Branch onto Master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM centos:7
 LABEL maintainer "Anthony Moulen <anthony_moulen@harvard.edu>"
 ENV TOMCAT_MAJOR="8" \
     TOMCAT_VERSION="8.5.45" \


### PR DESCRIPTION
Making Centos 7 the master branch.  Moving away from AmazonLInux.  Centos 6 also deprecated.